### PR TITLE
Change function signatures

### DIFF
--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -26,7 +26,7 @@ private let benchmarker = Benchmarker()
 
 public enum Level {
     case trace, debug, info, warning, error
-    
+
     var description: String {
         return String(describing: self).uppercased()
     }
@@ -45,31 +45,31 @@ public func <(x: Level, y: Level) -> Bool {
 open class Logger {
     /// The logger state.
     public var enabled: Bool = true
-    
+
     /// The logger formatter.
     public var formatter: Formatter {
         didSet { formatter.logger = self }
     }
-    
+
     /// The logger theme.
     public var theme: Theme?
-    
+
     /// The minimum level of severity.
     public var minLevel: Level
-    
+
     /// The logger format.
     public var format: String {
         return formatter.description
     }
-    
+
     /// The logger colors
     public var colors: String {
         return theme?.description ?? ""
     }
-    
+
     /// The queue used for logging.
     private let queue = DispatchQueue(label: "delba.log")
-    
+
     /**
      Creates and returns a new logger.
      
@@ -83,10 +83,10 @@ open class Logger {
         self.formatter = formatter
         self.theme = theme
         self.minLevel = minLevel
-        
+
         formatter.logger = self
     }
-    
+
     /**
      Logs a message with a trace severity level.
      
@@ -98,10 +98,10 @@ open class Logger {
      - parameter column:     The column at which the log happens.
      - parameter function:   The function in which the log happens.
      */
-    open func trace(_ items: Any..., separator: String = " ", terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
+    open func trace(_ items: Any?..., separator: String = " ", terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
         log(.trace, items, separator, terminator, file, line, column, function)
     }
-    
+
     /**
      Logs a message with a debug severity level.
      
@@ -113,10 +113,10 @@ open class Logger {
      - parameter column:     The column at which the log happens.
      - parameter function:   The function in which the log happens.
      */
-    open func debug(_ items: Any..., separator: String = " ", terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
+    open func debug(_ items: Any?..., separator: String = " ", terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
         log(.debug, items, separator, terminator, file, line, column, function)
     }
-    
+
     /**
      Logs a message with an info severity level.
      
@@ -128,10 +128,10 @@ open class Logger {
      - parameter column:     The column at which the log happens.
      - parameter function:   The function in which the log happens.
      */
-    open func info(_ items: Any..., separator: String = " ", terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
+    open func info(_ items: Any?..., separator: String = " ", terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
         log(.info, items, separator, terminator, file, line, column, function)
     }
-    
+
     /**
      Logs a message with a warning severity level.
      
@@ -143,10 +143,10 @@ open class Logger {
      - parameter column:     The column at which the log happens.
      - parameter function:   The function in which the log happens.
      */
-    open func warning(_ items: Any..., separator: String = " ", terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
+    open func warning(_ items: Any?..., separator: String = " ", terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
         log(.warning, items, separator, terminator, file, line, column, function)
     }
-    
+
     /**
      Logs a message with an error severity level.
      
@@ -158,10 +158,10 @@ open class Logger {
      - parameter column:     The column at which the log happens.
      - parameter function:   The function in which the log happens.
      */
-    open func error(_ items: Any..., separator: String = " ", terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
+    open func error(_ items: Any?..., separator: String = " ", terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
         log(.error, items, separator, terminator, file, line, column, function)
     }
-    
+
     /**
      Logs a message.
      
@@ -174,11 +174,11 @@ open class Logger {
      - parameter column:     The column at which the log happens.
      - parameter function:   The function in which the log happens.
      */
-    private func log(_ level: Level, _ items: [Any], _ separator: String, _ terminator: String, _ file: String, _ line: Int, _ column: Int, _ function: String) {
+    private func log(_ level: Level, _ items: [Any?], _ separator: String, _ terminator: String, _ file: String, _ line: Int, _ column: Int, _ function: String) {
         guard enabled && level >= minLevel else { return }
-        
+
         let date = Date()
-        
+
         let result = formatter.format(
             level: level,
             items: items,
@@ -190,12 +190,12 @@ open class Logger {
             function: function,
             date: date
         )
-        
+
         queue.async {
             Swift.print(result, separator: "", terminator: "")
         }
     }
-    
+
     /**
      Measures the performance of code.
      
@@ -209,11 +209,11 @@ open class Logger {
      */
     public func measure(_ description: String? = nil, iterations n: Int = 10, file: String = #file, line: Int = #line, column: Int = #column, function: String = #function, block: () -> Void) {
         guard enabled && .debug >= minLevel else { return }
-        
+
         let measure = benchmarker.measure(description, iterations: n, block: block)
-        
+
         let date = Date()
-        
+
         let result = formatter.format(
             description: measure.description,
             average: measure.average,
@@ -224,7 +224,7 @@ open class Logger {
             function: function,
             date: date
         )
-        
+
         queue.async {
             Swift.print(result)
         }


### PR DESCRIPTION
Change function signatures to silence the Swift 3 warning “Expression
implicitly coerced from ‘…’ to Any” that appears when passing an
optional.