### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Log",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Log",
+            targets: ["Log"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "Log",
+            dependencies: [],
+            path: "Source"),
+        .testTarget(
+            name: "LogTests",
+            dependencies: ["Log"],
+            path: "Tests"),
+    ]
+)

--- a/Source/Benchmarker.swift
+++ b/Source/Benchmarker.swift
@@ -22,6 +22,8 @@
 // SOFTWARE.
 //
 
+import Foundation
+
 internal class Benchmarker {
     typealias Result = (
         description: String?,

--- a/Source/Formatter.swift
+++ b/Source/Formatter.swift
@@ -22,6 +22,8 @@
 // SOFTWARE.
 //
 
+import Foundation
+
 public enum Component {
     case date(String)
     case message

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -22,6 +22,8 @@
 // SOFTWARE.
 //
 
+import Foundation
+
 private let benchmarker = Benchmarker()
 
 public enum Level {

--- a/Source/Supporting Files/Utilities.swift
+++ b/Source/Supporting Files/Utilities.swift
@@ -22,6 +22,8 @@
 // SOFTWARE.
 //
 
+import Foundation
+
 internal extension String {
     /// The last path component of the receiver.
     var lastPathComponent: String {

--- a/Source/Theme.swift
+++ b/Source/Theme.swift
@@ -22,6 +22,8 @@
 // SOFTWARE.
 //
 
+import Foundation
+
 public class Themes {}
 
 public class Theme: Themes {


### PR DESCRIPTION
Xcode complained about some missing symbols which were resolved by the Foundation imports. Besides that it seems to work fine now for use with Xcode 11's SwiftPM support 😊